### PR TITLE
Update `git stash pop` command

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@ While there _is_ a `git push --force` command, there isn't a `git pull --force` 
 4. Try to pull: what happens?
 5. Three options:
   1. Add and commit your changes, then `git pull`
-  2. `git stash`, then pull, and then `git pop`
+  2. `git stash`, then pull, and then `git stash pop`
   3. Take the changes on master and overwrite your own: `git reset --hard origin/master`
 
 ???


### PR DESCRIPTION
Hi @brianamarie! Thanks for the workshop at Git Merge! :)

I was just in your workshop and I found a small correction that I'd like to propose: to update one of the last slides from `git pop` to `git stash pop` -- because `git pop` isn't a standard git command (unless you've configured an alias, of course :) ).

Also, I'd love to meet you in person to talk about Git training - I'm setting up some Git training for people at my company (Booking.com) and wanted to talk to you about your experiences running training for Git. Will you be around on the conference day (1st Feb)? Thanks so much!